### PR TITLE
Support using importlib_resources (vs. importlib.resources)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,16 @@ embiggened = [proc.name for proc in std.PROCEDURES.values() if proc.has_embiggen
 print(f"Embiggened procedures in 4.1: {len(embiggened)}")
 # 154
 ```
+
+---
+
+This module will run with core Python 3.7.  If you are using an older
+version of Python, you can install additional PyPi packages to support
+the requirements of this module.  This has been tested with Python
+3.6:
+
+```
+virtualenv -m venv
+source venv/bin/activate
+pip install dataclasses importlib_resources
+```

--- a/src/pympistandard/__init__.py
+++ b/src/pympistandard/__init__.py
@@ -9,7 +9,13 @@ __version__ = "0.1.2"
 
 
 from pathlib import Path
-import importlib.resources
+try:
+    # importlib.resources became part of core Python in 3.7
+    import importlib.resources
+except ImportError:
+    # A backport named importlib_resources is available in PyPi for
+    # older versions of Python.
+    import importlib_resources
 import json
 from enum import Enum
 from typing import Union, Tuple, Optional


### PR DESCRIPTION
This module uses features that were introduced in Python 3.7:

* importlib.resources
* dataclasses

However, backports of those 2 classes are available on PyPi; installing them are known to make this module work properly with Python 3.6.

---

I raise this PR so that Open MPI can use this pympistandard module in RHEL8 (and similar) environments where Python 3.6 is the inbox version of Python provided by the OS.