### PR TITLE
Add Kind 'LOGICAL_VOID'

### DIFF
--- a/src/pympistandard/_kinds.py
+++ b/src/pympistandard/_kinds.py
@@ -268,6 +268,13 @@ LOGICAL_BOOLEAN = Kind(
     _f90_small="LOGICAL",
     _f08_small="LOGICAL",
 )
+LOGICAL_VOID = Kind(
+    name="LOGICAL_VOID",
+    _lis="logical",
+    _iso_c_small="void",
+    _f90_small="LOGICAL",
+    _f08_small="LOGICAL",
+)
 MATH = Kind(
     name="MATH",
     _lis="integer",


### PR DESCRIPTION
This Kind is referenced in the apis.json from MPI 5.0

Fixes #28 