### PR TITLE
Fix name output for profiling and embiggened functions

### DIFF
--- a/src/pympistandard/isoc.py
+++ b/src/pympistandard/isoc.py
@@ -201,8 +201,14 @@ class ProfilingMixin:
     @property
     def name(self) -> str:
         """Fetch the PMPI naming."""
+        # TODO is there a better way to print out the embiggened version of the
+        # profiling function?
+        if hasattr(self, "_embiggening"):
+            suffix = self._embiggening
+        else:
+            suffix = ""
 
-        return f"P{self._parseset['name']}"
+        return f"P{self._parseset['name']}{suffix}"
 
 
 class ISOCSymbol:


### PR DESCRIPTION
Without this, if the user requests the embiggened profiling version of a function, the library will only print out the name with "P" prepended to the function name and without the "_c" appended to the end.