### PR TITLE
Fix importlib_resources fallback in _load_bundled_db

### DIFF
--- a/src/pympistandard/__init__.py
+++ b/src/pympistandard/__init__.py
@@ -11,7 +11,7 @@ __version__ = "0.1.2"
 from pathlib import Path
 try:
     # importlib.resources became part of core Python in 3.7
-    import importlib.resources
+    import importlib.resources as importlib_resources
 except ImportError:
     # A backport named importlib_resources is available in PyPi for
     # older versions of Python.
@@ -140,13 +140,13 @@ def _register_kinds_v1() -> None:
 
 def _load_bundled_db():
     if sys.version_info.major == 3 and sys.version_info.minor < 9:
-        with importlib.resources.path(
+        with importlib_resources.path(
             "pympistandard.data", MPI_DATABASE_FILE
         ) as datapath:
             return datapath
 
     else:
-        return importlib.resources.files("pympistandard.data").joinpath(
+        return importlib_resources.files("pympistandard.data").joinpath(
             MPI_DATABASE_FILE
         )
 


### PR DESCRIPTION
## Problem

The module-level import in `src/pympistandard/__init__.py` tries `import importlib.resources` and, on `ImportError`, falls back to the PyPI backport `import importlib_resources`:

```python
try:
    # importlib.resources became part of core Python in 3.7
    import importlib.resources
except ImportError:
    # A backport named importlib_resources is available in PyPi for
    # older versions of Python.
    import importlib_resources
```

But `_load_bundled_db()` referenced `importlib.resources` directly:

```python
with importlib.resources.path("pympistandard.data", MPI_DATABASE_FILE) as datapath:
    ...
return importlib.resources.files("pympistandard.data").joinpath(MPI_DATABASE_FILE)
```

So on sles 15 which have Python 3.6 inbox, both the `.path()` and `.files()` calls raise NameError: name 'importlib' is not defined — the fallback import is never actually used.

## Fix

Import the core module under the `importlib_resources` alias so the same name refers to whichever implementation was successfully imported, and use that alias in `_load_bundled_db()`.